### PR TITLE
Update delete identity operation for upcoming API changes.

### DIFF
--- a/Disc/Networking/Resources/User/Identity/DeleteIdentity.swift
+++ b/Disc/Networking/Resources/User/Identity/DeleteIdentity.swift
@@ -8,7 +8,7 @@ private struct DeleteIdentityRequest: Request {
     let id: Int
     
     func build() -> NSURLRequest {
-        return createRequest(.GET, "api/user/identities/remove/\(id)", token: token)
+        return createRequest(.DELETE, "api/user/identities/\(id)", token: token)
     }
 }
 

--- a/DiscTests/Networking/Resources/User/Identity/DeleteIdentitySpec.swift
+++ b/DiscTests/Networking/Resources/User/Identity/DeleteIdentitySpec.swift
@@ -13,7 +13,7 @@ class DeleteIdentitySpec: QuickSpec {
                 
                 let id = 1234
                 
-                let matcher = api(.GET, "https://passport.thegrid.io/api/user/identities/remove/\(id)", token: token)
+                let matcher = api(.DELETE, "https://passport.thegrid.io/api/user/identities/\(id)", token: token)
                 let builder = http(204)
                 self.stub(matcher, builder: builder)
                 


### PR DESCRIPTION
This shouldn't be merged until the change is live in production.