### PR TITLE
Add support for adding identities via auth code.

### DIFF
--- a/Disc/Networking/Resources/User/Identity/AddIdentity.swift
+++ b/Disc/Networking/Resources/User/Identity/AddIdentity.swift
@@ -6,39 +6,103 @@ private struct AddIdentityRequest: Request {
     
     let token: String
     let provider: Provider
-    let providerAccessToken: String
+    let providerAccessToken: String?
     let providerTokenSecret: String?
+    let authCode: String?
+    let redirectUri: String?
+    
+    init(token: String, provider: Provider, providerAccessToken: String, providerTokenSecret: String?) {
+        self.token = token
+        self.provider = provider
+        self.providerAccessToken = providerAccessToken
+        self.providerTokenSecret = providerTokenSecret
+        self.authCode = .None
+        self.redirectUri = .None
+    }
+    
+    init(token: String, provider: Provider, authCode: String, redirectUri: String) {
+        self.token = token
+        self.provider = provider
+        self.providerAccessToken = .None
+        self.providerTokenSecret = .None
+        self.authCode = authCode
+        self.redirectUri = redirectUri
+    }
     
     func build() -> NSURLRequest {
         let defaultParameters = [
-            "provider": provider.rawValue,
-            "token": providerAccessToken
+            "provider": provider.rawValue
         ]
         
+        let tokenParameter: [String: AnyObject]
         let secretParameter: [String: AnyObject]
+        let authCodeParameter: [String: AnyObject]
+        let redirectUriParameter: [String: AnyObject]
+        
+        if let accessToken = providerAccessToken {
+            tokenParameter = [ "token": accessToken ]
+        } else {
+            tokenParameter = [:]
+        }
         
         if let secret = providerTokenSecret {
-            secretParameter = [
-                "token_secret": secret
-            ]
+            secretParameter = [ "token_secret": secret ]
         } else {
             secretParameter = [:]
         }
         
-        let body = defaultParameters + secretParameter
+        if let code = authCode {
+            authCodeParameter = [ "code": code ]
+        } else {
+            authCodeParameter = [:]
+        }
+        
+        if let redirect = redirectUri {
+            redirectUriParameter = [ "redirect_uri": redirect ]
+        } else {
+            redirectUriParameter = [:]
+        }
+        
+        let body = defaultParameters
+            + tokenParameter
+            + secretParameter
+            + authCodeParameter
+            + redirectUriParameter
         
         return createRequest(.POST, "api/user/identities", token: token, body: body)
     }
 }
 
 public extension APIClient {
-    /// Add the provided `identity`.
+    /// Add an `identity` using an access token.
     ///
     /// - parameter provider: The provider of the identity to add.
     /// - parameter token: The access token for the `provider`.
     /// - parameter secret: The token secret for the `provider`.
     func addIdentity(provider: Provider, token providerAccessToken: String, secret providerTokenSecret: String? = nil, completionHandler: Result<Identity, NSError> -> Void) {
-        let request = AddIdentityRequest(token: token, provider: provider, providerAccessToken: providerAccessToken, providerTokenSecret: providerTokenSecret)
+        let request = AddIdentityRequest(
+            token: token,
+            provider: provider,
+            providerAccessToken: providerAccessToken,
+            providerTokenSecret: providerTokenSecret
+        )
+        
+        client.performRequest(request, completionHandler: completionHandler)
+    }
+    
+    /// Add an `identity` using an auth code.
+    ///
+    /// - parameter provider: The provider of the identity to add.
+    /// - parameter code: The auth code for the `provider`.
+    /// - parameter redirectUri: The redirect URI for the `provider`.
+    func addIdentity(provider: Provider, code authCode: String, redirectUri: String, completionHandler: Result<Identity, NSError> -> Void) {
+        let request = AddIdentityRequest(
+            token: token,
+            provider: provider,
+            authCode: authCode,
+            redirectUri: redirectUri
+        )
+        
         client.performRequest(request, completionHandler: completionHandler)
     }
 }

--- a/DiscTests/Networking/Resources/User/Identity/AddIdentitySpec.swift
+++ b/DiscTests/Networking/Resources/User/Identity/AddIdentitySpec.swift
@@ -104,6 +104,34 @@ class AddIdentitySpec: QuickSpec {
                     expect(responseError).toEventually(beNil())
                 }
             }
+            
+            context("providing an auth code and redirect URI") {
+                it("should result in an identity") {
+                    let authCode = "provider auth code"
+                    let redirectUri = "redirect URI"
+                    
+                    let requestBody = [
+                        "provider": provider,
+                        "code": authCode,
+                        "redirect_uri": redirectUri
+                    ]
+                    
+                    let matcher = api(.POST, "https://passport.thegrid.io/api/user/identities", token: token, body: requestBody)
+                    let builder = json(responseBody)
+                    self.stub(matcher, builder: builder)
+                    
+                    var responseValue: Identity?
+                    var responseError: NSError?
+                    
+                    passport.addIdentity(identity.provider, code: authCode, redirectUri: redirectUri) { result in
+                        responseValue = result.value
+                        responseError = result.error
+                    }
+                    
+                    expect(responseValue).toEventually(equal(identity))
+                    expect(responseError).toEventually(beNil())
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
These changes add support for adding identities using an auth code and redirect URL.

Google on iOS requires this since it doesn't allow obtaining an access token directly. Instead, the auth code is exchanged for an access token on the server side.

This is a backwards compatible change.