### PR TITLE
Add support for login via OAuth providers

### DIFF
--- a/Disc/Networking/Authorization/CreateLoginUrl.swift
+++ b/Disc/Networking/Authorization/CreateLoginUrl.swift
@@ -11,12 +11,7 @@ public extension APIClient {
     /// - parameter scopes: The desired authentication scopes.
     /// - parameter provider: The desired identity provider, if any.
     static func createLoginUrl(clientId clientId: String, redirectUri: String, scopes: [Scope] = [], provider: Provider? = nil) -> NSURL? {
-        let queryItems = [
-            "client_id": clientId,
-            "redirect_uri": redirectUri,
-            "response_type": "code",
-            "scope": scopes.map({ $0.rawValue }).joinWithSeparator(",")
-        ]
+        let queryItems = createRequestParameters(clientId: clientId, redirectUri: redirectUri, scopes: scopes)
         
         let pathComponent: String
         

--- a/Disc/Networking/Authorization/GetAccessToken.swift
+++ b/Disc/Networking/Authorization/GetAccessToken.swift
@@ -4,24 +4,33 @@ import Swish
 private struct GetAccessTokenRequest: Request {
     typealias ResponseType = AccessToken
     
-    let clientId: String
-    let clientSecret: String
-    let code: String
+    private static let authLoginUrl = "api/auth/login"
+    
+    let url: String
+    let body: [String: String]
+    
+    init(clientId: String, clientSecret: String, code: String) {
+        url = "login/authorize/token"
+        body = createRequestParameters(clientId: clientId, clientSecret: clientSecret, code: code)
+    }
+    
+    init(clientId: String, scopes: [Scope] = [], provider: Provider, token: String, secret: String?) {
+        url = GetAccessTokenRequest.authLoginUrl
+        body = createRequestParameters(scopes: scopes, provider: provider, token: token, secret: secret)
+    }
+    
+    init(clientId: String, scopes: [Scope] = [], provider: Provider, code: String, redirectUri: String) {
+        url = GetAccessTokenRequest.authLoginUrl
+        body = createRequestParameters(scopes: scopes, provider: provider, code: code, redirectUri: redirectUri)
+    }
     
     func build() -> NSURLRequest {
-        let body = [
-            "client_id": clientId,
-            "client_secret": clientSecret,
-            "code": code,
-            "grant_type": "authorization_code",
-        ]
-        
-        return createRequest(.POST, "login/authorize/token", body: body)
+        return createRequest(.POST, url, body: body)
     }
 }
 
 public extension APIClient {
-    /// Get an access token using the provided `code`.
+    /// Get a Passport access token using a Passport auth `code`.
     ///
     /// - parameter clientId: The unique identifier of your application.
     /// - parameter clientSecret: Your application's passphrase.
@@ -29,6 +38,30 @@ public extension APIClient {
     /// parameter of the `redirectUri` that was passed to `init`.
     static func getAccessToken(clientId clientId: String, clientSecret: String, code: String, completionHandler: Result<AccessToken, NSError> -> Void) {
         let request = GetAccessTokenRequest(clientId: clientId, clientSecret: clientSecret, code: code)
+        staticClient.performRequest(request, completionHandler: completionHandler)
+    }
+    
+    /// Get a Passport access token using an OAuth provider access token.
+    ///
+    /// - parameter clientId: The unique identifier of your application.
+    /// - parameter scopes: The desired authentication scopes.
+    /// - parameter provider: The OAuth provider.
+    /// - parameter token: The access token for the `provider`.
+    /// - parameter secret: The token secret for the `provider`.
+    static func getAccessToken(clientId clientId: String, scopes: [Scope] = [], provider: Provider, token: String, secret: String? = nil, completionHandler: Result<AccessToken, NSError> -> Void) {
+        let request = GetAccessTokenRequest(clientId: clientId, scopes: scopes, provider: provider, token: token, secret: secret)
+        staticClient.performRequest(request, completionHandler: completionHandler)
+    }
+    
+    /// Get a Passport access token using an OAuth provider auth `code`.
+    ///
+    /// - parameter clientId: The unique identifier of your application.
+    /// - parameter scopes: The desired authentication scopes.
+    /// - parameter provider: The OAuth provider.
+    /// - parameter code: The auth code for the `provider`.
+    /// - parameter redirectUri: The redirect URI for the `provider`.
+    static func getAccessToken(clientId clientId: String, scopes: [Scope] = [], provider: Provider, code: String, redirectUri: String, completionHandler: Result<AccessToken, NSError> -> Void) {
+        let request = GetAccessTokenRequest(clientId: clientId, scopes: scopes, provider: provider, code: code, redirectUri: redirectUri)
         staticClient.performRequest(request, completionHandler: completionHandler)
     }
 }

--- a/Disc/Networking/Helpers/Request.swift
+++ b/Disc/Networking/Helpers/Request.swift
@@ -49,3 +49,60 @@ func createRequest(method: RequestMethod, _ path: String, token: String, body: [
 private func setAuthorizationHeaderForRequest(request: NSMutableURLRequest, token: String) {
     request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
 }
+
+private func createRequestParameters(clientId clientId: String) -> [String: String] {
+    return [ "client_id": clientId ]
+}
+
+private func createRequestParameters(code code: String) -> [String: String] {
+    return [ "code": code ]
+}
+
+private func createRequestParameters(provider provider: Provider) -> [String: String] {
+    return [ "provider": provider.rawValue ]
+}
+
+private func createRequestParameters(redirectUri redirectUri: String) -> [String: String] {
+    return [ "redirect_uri": redirectUri ]
+}
+
+private func createRequestParameters(secret secret: String?) -> [String: String] {
+    guard let secret = secret else { return [:] }
+    return [ "token_secret": secret ]
+}
+
+private func createRequestParameters(scopes scopes: [Scope]) -> [String: String] {
+    guard !scopes.isEmpty else { return [:] }
+    return [ "scope": scopes.map({ $0.rawValue }).joinWithSeparator(",") ]
+}
+
+private func createRequestParameters(token token: String) -> [String: String] {
+    return [ "token": token ]
+}
+
+func createRequestParameters(clientId clientId: String, redirectUri: String, scopes: [Scope]) -> [String: String] {
+    return createRequestParameters(clientId: clientId)
+        + createRequestParameters(scopes: scopes)
+        + createRequestParameters(redirectUri: redirectUri)
+        + [ "response_type": "code" ]
+}
+
+func createRequestParameters(clientId clientId: String, clientSecret: String, code: String) -> [String: String] {
+    return createRequestParameters(clientId: clientId)
+        + createRequestParameters(code: code)
+        + [ "client_secret": clientSecret, "grant_type": "authorization_code" ]
+}
+
+func createRequestParameters(scopes scopes: [Scope] = [], provider: Provider, token: String, secret: String? = .None) -> [String: String] {
+    return createRequestParameters(scopes: scopes)
+        + createRequestParameters(provider: provider)
+        + createRequestParameters(token: token)
+        + createRequestParameters(secret: secret)
+}
+
+func createRequestParameters(scopes scopes: [Scope] = [], provider: Provider, code: String, redirectUri: String) -> [String: String] {
+    return createRequestParameters(scopes: scopes)
+        + createRequestParameters(provider: provider)
+        + createRequestParameters(code: code)
+        + createRequestParameters(redirectUri: redirectUri)
+}

--- a/Disc/Networking/Helpers/Request.swift
+++ b/Disc/Networking/Helpers/Request.swift
@@ -3,6 +3,9 @@ import Swish
 
 private let baseUrl = NSURL(string: "https://passport.thegrid.io/")!
 
+
+// MARK: - URL
+
 func createUrl(path: String, _ queryItems: [String: String] = [:]) -> NSURL? {
     guard let url = NSURL(string: path, relativeToURL: baseUrl),
         components = NSURLComponents(URL: url, resolvingAgainstBaseURL: true)
@@ -17,6 +20,9 @@ func createUrl(path: String, _ queryItems: [String: String] = [:]) -> NSURL? {
     components.queryItems = queryItems.isEmpty ? nil : queryItems
     return components.URL
 }
+
+
+// MARK: - Request
 
 func createRequest(method: RequestMethod, _ path: String, token: String) -> NSMutableURLRequest {
     let request = createRequest(method, path)
@@ -49,6 +55,9 @@ func createRequest(method: RequestMethod, _ path: String, token: String, body: [
 private func setAuthorizationHeaderForRequest(request: NSMutableURLRequest, token: String) {
     request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
 }
+
+
+// MARK: - Request Parameters
 
 private func createRequestParameters(clientId clientId: String) -> [String: String] {
     return [ "client_id": clientId ]

--- a/Disc/Networking/Resources/User/Identity/AddIdentity.swift
+++ b/Disc/Networking/Resources/User/Identity/AddIdentity.swift
@@ -5,70 +5,19 @@ private struct AddIdentityRequest: Request {
     typealias ResponseType = Identity
     
     let token: String
-    let provider: Provider
-    let providerAccessToken: String?
-    let providerTokenSecret: String?
-    let authCode: String?
-    let redirectUri: String?
+    let body: [String: String]
     
     init(token: String, provider: Provider, providerAccessToken: String, providerTokenSecret: String?) {
         self.token = token
-        self.provider = provider
-        self.providerAccessToken = providerAccessToken
-        self.providerTokenSecret = providerTokenSecret
-        self.authCode = .None
-        self.redirectUri = .None
+        body = createRequestParameters(provider: provider, token: providerAccessToken, secret: providerTokenSecret)
     }
     
     init(token: String, provider: Provider, authCode: String, redirectUri: String) {
         self.token = token
-        self.provider = provider
-        self.providerAccessToken = .None
-        self.providerTokenSecret = .None
-        self.authCode = authCode
-        self.redirectUri = redirectUri
+        body = createRequestParameters(provider: provider, code: authCode, redirectUri: redirectUri)
     }
     
     func build() -> NSURLRequest {
-        let defaultParameters = [
-            "provider": provider.rawValue
-        ]
-        
-        let tokenParameter: [String: AnyObject]
-        let secretParameter: [String: AnyObject]
-        let authCodeParameter: [String: AnyObject]
-        let redirectUriParameter: [String: AnyObject]
-        
-        if let accessToken = providerAccessToken {
-            tokenParameter = [ "token": accessToken ]
-        } else {
-            tokenParameter = [:]
-        }
-        
-        if let secret = providerTokenSecret {
-            secretParameter = [ "token_secret": secret ]
-        } else {
-            secretParameter = [:]
-        }
-        
-        if let code = authCode {
-            authCodeParameter = [ "code": code ]
-        } else {
-            authCodeParameter = [:]
-        }
-        
-        if let redirect = redirectUri {
-            redirectUriParameter = [ "redirect_uri": redirect ]
-        } else {
-            redirectUriParameter = [:]
-        }
-        
-        let body = defaultParameters
-            + tokenParameter
-            + secretParameter
-            + authCodeParameter
-            + redirectUriParameter
-        
         return createRequest(.POST, "api/user/identities", token: token, body: body)
     }
 }

--- a/DiscTests/Networking/Authorization/CreateLoginUrlSpec.swift
+++ b/DiscTests/Networking/Authorization/CreateLoginUrlSpec.swift
@@ -16,7 +16,6 @@ class CreateLoginUrlSpec: QuickSpec {
                         + "?client_id=\(clientId)"
                         + "&redirect_uri=\(redirectUri)"
                         + "&response_type=code"
-                        + "&scope="
                     
                     let expectedUrl = NSURL(string: expectedUrlString)
                     
@@ -33,7 +32,6 @@ class CreateLoginUrlSpec: QuickSpec {
                         + "?client_id=\(clientId)"
                         + "&redirect_uri=\(redirectUri)"
                         + "&response_type=code"
-                        + "&scope="
                     
                     let expectedUrl = NSURL(string: expectedUrlString)
                     expect(url).to(equal(expectedUrl))

--- a/DiscTests/Networking/Authorization/CreateLoginUrlSpec.swift
+++ b/DiscTests/Networking/Authorization/CreateLoginUrlSpec.swift
@@ -6,7 +6,6 @@ class CreateLoginUrlSpec: QuickSpec {
     override func spec() {
         describe("creating a login URL") {
             let clientId = "id"
-            let clientSecret = "secret"
             let redirectUri = "uri://"
             
             context("not specifying scopes or a provider") {

--- a/DiscTests/Networking/Resources/User/Identity/AddIdentitySpec.swift
+++ b/DiscTests/Networking/Resources/User/Identity/AddIdentitySpec.swift
@@ -54,7 +54,7 @@ class AddIdentitySpec: QuickSpec {
                 )
             }
             
-            context("providing only an access token") {
+            context("with only an access token") {
                 it("should result in an identity") {
                     let requestBody = [
                         "provider": provider,
@@ -78,7 +78,7 @@ class AddIdentitySpec: QuickSpec {
                 }
             }
             
-            context("providing a token secret") {
+            context("with an access token and secret") {
                 it("should result in an identity") {
                     let providerTokenSecret = "provider token secret"
                     
@@ -105,7 +105,7 @@ class AddIdentitySpec: QuickSpec {
                 }
             }
             
-            context("providing an auth code and redirect URI") {
+            context("with an auth code and redirect URI") {
                 it("should result in an identity") {
                     let authCode = "provider auth code"
                     let redirectUri = "redirect URI"


### PR DESCRIPTION
This is a spiritual successor to #11, and aims to close #10.

In short, it extracts some of the logic for adding an identities via OAuth providers so that it may also be used for logging in.

Unlike #11, it does not add support for the `/api/auth/token` endpoint. I have some questions/reservations around this that I'll put in a separate issue. I believe we're not using it (yet) anyway.

cc @nickvelloff