### PR TITLE
add support for clientId to GetAccessTokenRequest

### DIFF
--- a/Disc/Networking/Authorization/GetAccessToken.swift
+++ b/Disc/Networking/Authorization/GetAccessToken.swift
@@ -14,16 +14,6 @@ private struct GetAccessTokenRequest: Request {
         body = createRequestParameters(clientId: clientId, clientSecret: clientSecret, code: code)
     }
     
-    init(scopes: [Scope] = [], provider: Provider, token: String, secret: String?) {
-        url = GetAccessTokenRequest.authLoginUrl
-        body = createRequestParameters(scopes: scopes, provider: provider, token: token, secret: secret)
-    }
-    
-    init(scopes: [Scope] = [], provider: Provider, code: String, redirectUri: String) {
-        url = GetAccessTokenRequest.authLoginUrl
-        body = createRequestParameters(scopes: scopes, provider: provider, code: code, redirectUri: redirectUri)
-    }
-    
     init(clientId: String, scopes: [Scope] = [], provider: Provider, token: String, secret: String?) {
         url = GetAccessTokenRequest.authLoginUrl
         body = createRequestParameters(clientId: clientId, scopes: scopes, provider: provider, token: token, secret: secret)

--- a/Disc/Networking/Authorization/GetAccessToken.swift
+++ b/Disc/Networking/Authorization/GetAccessToken.swift
@@ -14,14 +14,24 @@ private struct GetAccessTokenRequest: Request {
         body = createRequestParameters(clientId: clientId, clientSecret: clientSecret, code: code)
     }
     
-    init(clientId: String, scopes: [Scope] = [], provider: Provider, token: String, secret: String?) {
+    init(scopes: [Scope] = [], provider: Provider, token: String, secret: String?) {
         url = GetAccessTokenRequest.authLoginUrl
         body = createRequestParameters(scopes: scopes, provider: provider, token: token, secret: secret)
     }
     
-    init(clientId: String, scopes: [Scope] = [], provider: Provider, code: String, redirectUri: String) {
+    init(scopes: [Scope] = [], provider: Provider, code: String, redirectUri: String) {
         url = GetAccessTokenRequest.authLoginUrl
         body = createRequestParameters(scopes: scopes, provider: provider, code: code, redirectUri: redirectUri)
+    }
+    
+    init(clientId: String, scopes: [Scope] = [], provider: Provider, token: String, secret: String?) {
+        url = GetAccessTokenRequest.authLoginUrl
+        body = createRequestParameters(clientId: clientId, scopes: scopes, provider: provider, token: token, secret: secret)
+    }
+    
+    init(clientId: String, scopes: [Scope] = [], provider: Provider, code: String, redirectUri: String) {
+        url = GetAccessTokenRequest.authLoginUrl
+        body = createRequestParameters(clientId: clientId, scopes: scopes, provider: provider, code: code, redirectUri: redirectUri)
     }
     
     func build() -> NSURLRequest {

--- a/Disc/Networking/Helpers/Request.swift
+++ b/Disc/Networking/Helpers/Request.swift
@@ -115,3 +115,19 @@ func createRequestParameters(scopes scopes: [Scope] = [], provider: Provider, co
         + createRequestParameters(code: code)
         + createRequestParameters(redirectUri: redirectUri)
 }
+
+func createRequestParameters(clientId clientId: String, scopes: [Scope] = [], provider: Provider, token: String, secret: String? = .None) -> [String: String] {
+    return createRequestParameters(clientId: clientId)
+        + createRequestParameters(scopes: scopes)
+        + createRequestParameters(provider: provider)
+        + createRequestParameters(token: token)
+        + createRequestParameters(secret: secret)
+}
+
+func createRequestParameters(clientId clientId: String, scopes: [Scope] = [], provider: Provider, code: String, redirectUri: String) -> [String: String] {
+    return createRequestParameters(clientId: clientId)
+        + createRequestParameters(scopes: scopes)
+        + createRequestParameters(provider: provider)
+        + createRequestParameters(code: code)
+        + createRequestParameters(redirectUri: redirectUri)
+}

--- a/Disc/Networking/Helpers/Request.swift
+++ b/Disc/Networking/Helpers/Request.swift
@@ -118,16 +118,10 @@ func createRequestParameters(scopes scopes: [Scope] = [], provider: Provider, co
 
 func createRequestParameters(clientId clientId: String, scopes: [Scope] = [], provider: Provider, token: String, secret: String? = .None) -> [String: String] {
     return createRequestParameters(clientId: clientId)
-        + createRequestParameters(scopes: scopes)
-        + createRequestParameters(provider: provider)
-        + createRequestParameters(token: token)
-        + createRequestParameters(secret: secret)
+        + createRequestParameters(scopes: scopes, provider: provider, token: token, secret: secret)
 }
 
 func createRequestParameters(clientId clientId: String, scopes: [Scope] = [], provider: Provider, code: String, redirectUri: String) -> [String: String] {
     return createRequestParameters(clientId: clientId)
-        + createRequestParameters(scopes: scopes)
-        + createRequestParameters(provider: provider)
-        + createRequestParameters(code: code)
-        + createRequestParameters(redirectUri: redirectUri)
+        + createRequestParameters(scopes: scopes, provider: provider, code: code, redirectUri: redirectUri)
 }

--- a/DiscTests/Networking/Authorization/GetAccessTokenSpec.swift
+++ b/DiscTests/Networking/Authorization/GetAccessTokenSpec.swift
@@ -86,6 +86,7 @@ class GetAccessTokenSpec: QuickSpec {
                     context("without scopes") {
                         it("should result in an access token") {
                             let requestBody = [
+                                "client_id": clientId,
                                 "provider": provider.rawValue,
                                 "token": providerAccessToken,
                             ]
@@ -110,6 +111,7 @@ class GetAccessTokenSpec: QuickSpec {
                     context("with scopes") {
                         it("should result in an access token") {
                             let requestBody: [String: AnyObject] = [
+                                "client_id": clientId,
                                 "provider": provider.rawValue,
                                 "scope": "\(scopes.first!.rawValue),\(scopes.last!.rawValue)",
                                 "token": providerAccessToken
@@ -137,6 +139,7 @@ class GetAccessTokenSpec: QuickSpec {
                     context("without scopes") {
                         it("should result in an access token") {
                             let requestBody = [
+                                "client_id": clientId,
                                 "provider": provider.rawValue,
                                 "token": providerAccessToken,
                                 "token_secret": providerTokenSecret
@@ -162,6 +165,7 @@ class GetAccessTokenSpec: QuickSpec {
                     context("with scopes") {
                         it("should result in an access token") {
                             let requestBody: [String: AnyObject] = [
+                                "client_id": clientId,
                                 "provider": provider.rawValue,
                                 "scope": "\(scopes.first!.rawValue),\(scopes.last!.rawValue)",
                                 "token": providerAccessToken,
@@ -190,6 +194,7 @@ class GetAccessTokenSpec: QuickSpec {
                     context("without scopes") {
                         it("should result in an access token") {
                             let requestBody = [
+                                "client_id": clientId,
                                 "provider": provider.rawValue,
                                 "code": providerAuthCode,
                                 "redirect_uri": providerRedirectUri
@@ -215,6 +220,7 @@ class GetAccessTokenSpec: QuickSpec {
                     context("with scopes") {
                         it("should result in an access token") {
                             let requestBody: [String: AnyObject] = [
+                                "client_id": clientId,
                                 "code": providerAuthCode,
                                 "provider": provider.rawValue,
                                 "redirect_uri": providerRedirectUri,


### PR DESCRIPTION
• `clientId` was getting dropped from the request, so I added it
• the original requests were maintained to support `AddIdentity`
• testing with the Grid app