### PR TITLE
Update test script to fail early.

### DIFF
--- a/script/test
+++ b/script/test
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-xcodebuild -workspace Disc.xcworkspace -scheme Disc-Mac -sdk macosx clean test
+xcodebuild -workspace Disc.xcworkspace -scheme Disc-Mac -sdk macosx clean test &&
 xcodebuild -workspace Disc.xcworkspace -scheme Disc-iOS -sdk iphonesimulator clean test


### PR DESCRIPTION
This will prevent the iOS build and test from running if the Mac build fails.