### PR TITLE
naming fix

### DIFF
--- a/Disc/Networking/Authorization/GetAccessToken.swift
+++ b/Disc/Networking/Authorization/GetAccessToken.swift
@@ -92,7 +92,7 @@ public extension APIClient {
     ///
     /// - parameter clientId: The unique identifier of your application.
     /// - parameter refreshToken: The passport provided refresh token.
-    static func getRefreshToken(clientId clientId: String, refreshToken: String, completionHandler: Result<AccessToken, SwishError> -> Void) {
+    static func getAccessToken(clientId clientId: String, refreshToken: String, completionHandler: Result<AccessToken, SwishError> -> Void) {
         let request = GetAccessTokenRequest(clientId: clientId, refreshToken: refreshToken)
         staticClient.performRequest(request, completionHandler: completionHandler)
     }

--- a/DiscTests/RefreshAccessTokenSpec.swift
+++ b/DiscTests/RefreshAccessTokenSpec.swift
@@ -40,7 +40,7 @@ class RefreshAccessTokenSpec: QuickSpec {
                     var responseValue: AccessToken?
                     var responseError: SwishError?
                     
-                    APIClient.getRefreshToken(clientId: clientId, refreshToken: refreshToken) { result in
+                    APIClient.getAccessToken(clientId: clientId, refreshToken: refreshToken) { result in
                         responseValue = result.value
                         responseError = result.error
                     }


### PR DESCRIPTION
rename `getRefreshToken` to `getAccessToken` as that is more accurate